### PR TITLE
Update homepage resource links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ HERO (Swap hero.jpg, title, strapline, and the three links)
 
 **One sentence on impact:** In 3 days, we explore how communities navigate transformative environmental change, producing actionable visuals, a concise brief, and shareable code for partners.
 
-**[Project brief (PDF)](#) · [View shared code](https://github.com/CU-ESIIL/social-impacts-of-transformations-innovation-summit-2025__14/tree/main/code) · [Data & access](data.md)**
+**[Project brief (PDF)](assets/Seven%20ways%20to%20measure%20fire%20polygon%20velocity-4.pdf) · [View shared code](https://github.com/CU-ESIIL/social-impacts-of-transformations-innovation-summit-2025__14/blob/main/code/fired_time_hull_panel.ipynb) · [Explore data](https://github.com/CU-ESIIL/social-impacts-of-transformations-innovation-summit-2025__14/blob/main/code/prism_quicklook.py)**
 
 > **About this site:** This is a public, in-progress record of the Social Impacts of Transformations team at the 2025 Innovation Summit. Edit everything here in your browser: open a file → pencil icon → Commit changes.
 
@@ -160,7 +160,7 @@ Explain who is impacted and how this could change decisions or understanding.
   <a href="https://github.com/CU-ESIIL/social-impacts-of-transformations-innovation-summit-2025__14/blob/main/code/fired_time_hull_panel.ipynb"><img src="assets/button_code.gif" alt="View shared code" width="240"><br><strong>View code</strong></a>
 </td>
 <td align="center" width="33%">
-  <a href="https://github.com/CU-ESIIL/social-impacts-of-transformations-innovation-summit-2025__14/blob/main/code/single_hull_demo.py"><img src="assets/button_data.gif" alt="Explore data" width="240"><br><strong>Explore data</strong></a>
+  <a href="https://github.com/CU-ESIIL/social-impacts-of-transformations-innovation-summit-2025__14/blob/main/code/prism_quicklook.py"><img src="assets/button_data.gif" alt="Explore data" width="240"><br><strong>Explore data</strong></a>
 </td>
 </tr>
 </table>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ nav:
   - Storage:
       - Your code: https://github.com/CU-ESIIL/social-impacts-of-transformations-innovation-summit-2025__14/tree/main/code
       - Your documentation: https://github.com/CU-ESIIL/social-impacts-of-transformations-innovation-summit-2025__14/tree/main/documentation
-      - Your persistent storage: https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_14
+      - Your persistent storage: https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_14?type=folder&resourceId=fbbbc478-95a1-11f0-b0fb-90e2ba675364
   - Orientation:
       - Summit slides: orientation/slides.md
       - ESIIL training: orientation/esiil_training.md


### PR DESCRIPTION
## Summary
- point homepage hero links to the final brief PDF, featured notebook, and data exploration script
- direct the featured image buttons to the same brief, notebook, and data exploration resources and update the persistent storage nav link

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d168d518e88325bfcaf270faf38894